### PR TITLE
支持标准 dsh plugin github 安装：prepare 自编译 + esbuild 前移 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,21 @@ dsh 的大会话在手机上看很慢——历史记录一次要拉好几 MB 的
 
 ## 安装
 
-前置要求：dsh（DeepSeek Harness）0.x、Node.js ≥ 22。
-
-```sh
-npm install   # esbuild（构建）+ web-push（运行时，仅通知功能需要）
-npm run build # 产出 lib/index.js（host）+ lib/client.js（browser）
+```powershell
+dsh plugin --profile web add github:better-er/dsh-meow-smooth
 ```
 
-构建**零 dsh 本体依赖**，不需要安装任何 `@deepseek-ai/*` 包。
+一条命令装完即生效，自动挂载，重启 DSH web 后启用，无需手工编辑任何组合文件。包内含 `prepare` 脚本，安装时自动编译，装完即用。
 
-装配（二选一）：
+> ⚠️ **过时**：npm 源安装 `dsh plugin --profile web add meow-smooth` 已不再推荐，仅旧版本可用（`0.6.0` 的 `package.json` 带 BOM 会解析失败）。请改用上面的 GitHub 源。
 
-- **profile 装配**：把 `cordis.patch.yml` 的 insert 条目加进目标 profile 的 `cordis.patch.yml`（或把本包加入 profile 的 bundles 列表），重启 dsh 生效；
-- **npm 包安装**：`npm pack` 产出 tgz，在 dsh profile 里 `npm install <tgz>`；浏览器端自动装配，host 侧经 `cordis.patch.yml` insert 条目加载。
+## 卸载
+
+```powershell
+dsh plugin --profile web remove meow-smooth
+```
+
+彻底移除，重启 DSH web 后不再加载。
 
 ## 通知功能（可选）
 

--- a/package.json
+++ b/package.json
@@ -42,14 +42,13 @@
     }
   },
   "scripts": {
+    "prepare": "node build.mjs",
     "build": "node build.mjs",
     "watch": "node build.mjs --watch",
     "link-workspace": "powershell -ExecutionPolicy Bypass -File scripts/link-workspace.ps1"
   },
   "dependencies": {
-    "web-push": "^3.6.7"
-  },
-  "devDependencies": {
+    "web-push": "^3.6.7",
     "esbuild": "^0.25.0"
   }
 }


### PR DESCRIPTION
# 支持标准 dsh plugin github 安装

## 背景

当前 `meow-smooth` 用 `dsh plugin --profile web add github:<owner>/dsh-meow-smooth` 从 GitHub 安装时会炸：装进去缺 `lib/`，cordis 加载 `lib/index.js` 报 `ERR_MODULE_NOT_FOUND`，整个 profile 启动失败。

根因：仓库的 `lib/` 被 `.gitignore` 忽略、不入 git，且 `package.json` **没有** `prepare` 钩子，git 安装时没人会自动编译 `lib/`。

另外，npm 源安装已**过时**：`0.6.0` 的 `package.json` 带 BOM，`JSON.parse` 会报 `SyntaxError: Unexpected token '\uFEFF'`，无法通过 `dsh plugin --profile web add meow-smooth` 安装。本 PR 一并把 README 安装说明切换到 GitHub 源并标记 npm 源过时。

## 改动

### `package.json`

- 新增 `scripts.prepare: "node build.mjs"`：git 或源码安装时自动编译出 `lib/index.js` 与 `lib/client.js`。
- 把 `esbuild` 从 `devDependencies` 前移到 `dependencies`：因为 git 源按生产依赖安装，只装 `dependencies` 里的包；若 esbuild 留在 `devDependencies`，prepare 阶段会因 `Cannot find module 'esbuild'` 失败，前移后 git 安装会自动带上 esbuild 并完成构建。

### `README.md`

- 安装说明统一为 `dsh plugin --profile web add github:...` 一条命令。
- 新增 `## 卸载` 小节。
- 标记 npm 源安装（`add meow-smooth`）为**过时**：`0.6.0` 的 `package.json` 带 BOM，`JSON.parse` 会报 `SyntaxError: Unexpected token '\uFEFF'`，无法用 npm 源安装。

## 验证

- 在无 `lib/` 的干净 git 源安装实测：pnpm 自动跑 `npm install` 与 `prepare`，成功构建出 `lib/index.js`（35.6kb）与 `lib/client.js`（85kb），与本地构建产物一致。
- 装配后 `dsh web` 正常启动，无 meow/模块错误。

## 影响

- 仅影响安装与构建路径，运行产物与行为不变。
- 为从 git 安装的用户多拉一个构建期依赖 esbuild，换取「装即不炸」的自愈能力。
- git 安装时可能会报「未信任 / Ignored build scripts」：pnpm（9/10 默认）禁止未信任依赖跑 `prepare`，首次安装需放行 `esbuild` 与 `meow-smooth`，方式为在 profile 的 `pnpm-workspace.yaml` 里配 `onlyBuiltDependencies` 或执行 `pnpm approve-builds`。
